### PR TITLE
wip: cloudsplaining single policy

### DIFF
--- a/content/actions/what-perms-are-granted-to-role/README.md
+++ b/content/actions/what-perms-are-granted-to-role/README.md
@@ -1,0 +1,261 @@
+## Determine permissions (and least privilege violations) for an IAM role
+
+Returns the policies attached to or embedded in an IAM role, along with cloudsplainer findings. 
+
+### Sample Input:
+```json
+{
+  "roleName": "ec2-dynamofull-test"
+}
+```
+
+### Sample Output:
+```json
+{
+  "result": 
+    {
+      "Policies": [
+         {
+            "PolicyArn":"arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
+            "PolicyName":"AmazonDynamoDBFullAccess",
+            "PolicyDocument":{
+               "Version":"2012-10-17",
+               "Statement":[
+                  {
+                     "Action":[
+                        "dynamodb:*",
+                        "dax:*",
+                        "application-autoscaling:DeleteScalingPolicy",
+                        "application-autoscaling:DeregisterScalableTarget",
+                        "application-autoscaling:DescribeScalableTargets",
+                        "application-autoscaling:DescribeScalingActivities",
+                        "application-autoscaling:DescribeScalingPolicies",
+                        "application-autoscaling:PutScalingPolicy",
+                        "application-autoscaling:RegisterScalableTarget",
+                        "cloudwatch:DeleteAlarms",
+                        "cloudwatch:DescribeAlarmHistory",
+                        "cloudwatch:DescribeAlarms",
+                        "cloudwatch:DescribeAlarmsForMetric",
+                        "cloudwatch:GetMetricStatistics",
+                        "cloudwatch:ListMetrics",
+                        "cloudwatch:PutMetricAlarm",
+                        "cloudwatch:GetMetricData",
+                        "datapipeline:ActivatePipeline",
+                        "datapipeline:CreatePipeline",
+                        "datapipeline:DeletePipeline",
+                        "datapipeline:DescribeObjects",
+                        "datapipeline:DescribePipelines",
+                        "datapipeline:GetPipelineDefinition",
+                        "datapipeline:ListPipelines",
+                        "datapipeline:PutPipelineDefinition",
+                        "datapipeline:QueryObjects",
+                        "ec2:DescribeVpcs",
+                        "ec2:DescribeSubnets",
+                        "ec2:DescribeSecurityGroups",
+                        "iam:GetRole",
+                        "iam:ListRoles",
+                        "kms:DescribeKey",
+                        "kms:ListAliases",
+                        "sns:CreateTopic",
+                        "sns:DeleteTopic",
+                        "sns:ListSubscriptions",
+                        "sns:ListSubscriptionsByTopic",
+                        "sns:ListTopics",
+                        "sns:Subscribe",
+                        "sns:Unsubscribe",
+                        "sns:SetTopicAttributes",
+                        "lambda:CreateFunction",
+                        "lambda:ListFunctions",
+                        "lambda:ListEventSourceMappings",
+                        "lambda:CreateEventSourceMapping",
+                        "lambda:DeleteEventSourceMapping",
+                        "lambda:GetFunctionConfiguration",
+                        "lambda:DeleteFunction",
+                        "resource-groups:ListGroups",
+                        "resource-groups:ListGroupResources",
+                        "resource-groups:GetGroup",
+                        "resource-groups:GetGroupQuery",
+                        "resource-groups:DeleteGroup",
+                        "resource-groups:CreateGroup",
+                        "tag:GetResources",
+                        "kinesis:ListStreams",
+                        "kinesis:DescribeStream",
+                        "kinesis:DescribeStreamSummary"
+                     ],
+                     "Effect":"Allow",
+                     "Resource":"*"
+                  },
+                  {
+                     "Action":"cloudwatch:GetInsightRuleReport",
+                     "Effect":"Allow",
+                     "Resource":"arn:aws:cloudwatch:*:*:insight-rule/DynamoDBContributorInsights*"
+                  },
+                  {
+                     "Action":[
+                        "iam:PassRole"
+                     ],
+                     "Effect":"Allow",
+                     "Resource":"*",
+                     "Condition":{
+                        "StringLike":{
+                           "iam:PassedToService":[
+                              "application-autoscaling.amazonaws.com",
+                              "application-autoscaling.amazonaws.com.cn",
+                              "dax.amazonaws.com"
+                           ]
+                        }
+                     }
+                  },
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "iam:CreateServiceLinkedRole"
+                     ],
+                     "Resource":"*",
+                     "Condition":{
+                        "StringEquals":{
+                           "iam:AWSServiceName":[
+                              "replication.dynamodb.amazonaws.com",
+                              "dax.amazonaws.com",
+                              "dynamodb.application-autoscaling.amazonaws.com",
+                              "contributorinsights.dynamodb.amazonaws.com",
+                              "kinesisreplication.dynamodb.amazonaws.com"
+                           ]
+                        }
+                     }
+                  }
+               ]
+            },
+            "PolicyFindings":{
+               "ServiceWildcard":[
+                  "dax",
+                  "dynamodb"
+               ],
+               "ServicesAffected":[
+                  "cloudwatch",
+                  "dax",
+                  "dynamodb",
+                  "iam",
+                  "lambda",
+                  "resource-groups",
+                  "sns"
+               ],
+               "PrivilegeEscalation":[
+                  
+               ],
+               "ResourceExposure":[
+                  "sns:SetTopicAttributes",
+                  "sns:CreateTopic",
+                  "iam:PassRole",
+                  "iam:CreateServiceLinkedRole"
+               ],
+               "DataExfiltration":[
+                  
+               ],
+               "CredentialsExposure":[
+                  
+               ],
+               "InfrastructureModification":[
+                  "cloudwatch:DeleteAlarms",
+                  "cloudwatch:PutMetricAlarm",
+                  "dax:BatchWriteItem",
+                  "dax:CreateCluster",
+                  "dax:DecreaseReplicationFactor",
+                  "dax:DeleteCluster",
+                  "dax:DeleteItem",
+                  "dax:IncreaseReplicationFactor",
+                  "dax:PutItem",
+                  "dax:RebootNode",
+                  "dax:TagResource",
+                  "dax:UntagResource",
+                  "dax:UpdateCluster",
+                  "dax:UpdateItem",
+                  "dynamodb:BatchWriteItem",
+                  "dynamodb:CreateBackup",
+                  "dynamodb:CreateGlobalTable",
+                  "dynamodb:CreateTable",
+                  "dynamodb:CreateTableReplica",
+                  "dynamodb:DeleteBackup",
+                  "dynamodb:DeleteItem",
+                  "dynamodb:DeleteTable",
+                  "dynamodb:DeleteTableReplica",
+                  "dynamodb:DisableKinesisStreamingDestination",
+                  "dynamodb:EnableKinesisStreamingDestination",
+                  "dynamodb:ExportTableToPointInTime",
+                  "dynamodb:PartiQLDelete",
+                  "dynamodb:PartiQLInsert",
+                  "dynamodb:PartiQLUpdate",
+                  "dynamodb:PutItem",
+                  "dynamodb:RestoreTableFromBackup",
+                  "dynamodb:RestoreTableToPointInTime",
+                  "dynamodb:TagResource",
+                  "dynamodb:UntagResource",
+                  "dynamodb:UpdateContinuousBackups",
+                  "dynamodb:UpdateContributorInsights",
+                  "dynamodb:UpdateGlobalTable",
+                  "dynamodb:UpdateGlobalTableSettings",
+                  "dynamodb:UpdateItem",
+                  "dynamodb:UpdateTable",
+                  "dynamodb:UpdateTableReplicaAutoScaling",
+                  "dynamodb:UpdateTimeToLive",
+                  "iam:CreateServiceLinkedRole",
+                  "iam:PassRole",
+                  "lambda:CreateFunction",
+                  "lambda:DeleteEventSourceMapping",
+                  "lambda:DeleteFunction",
+                  "resource-groups:DeleteGroup",
+                  "sns:CreateTopic",
+                  "sns:DeleteTopic",
+                  "sns:SetTopicAttributes",
+                  "sns:Subscribe"
+               ]
+            }
+         },
+         {
+            "PolicyArn":"arn:aws:iam::aws:policy/IAMReadOnlyAccess",
+            "PolicyName":"IAMReadOnlyAccess",
+            "PolicyDocument":{
+               "Version":"2012-10-17",
+               "Statement":[
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "iam:GenerateCredentialReport",
+                        "iam:GenerateServiceLastAccessedDetails",
+                        "iam:Get*",
+                        "iam:List*",
+                        "iam:SimulateCustomPolicy",
+                        "iam:SimulatePrincipalPolicy"
+                     ],
+                     "Resource":"*"
+                  }
+               ]
+            },
+            "PolicyFindings":{
+               "ServiceWildcard":[
+                  
+               ],
+               "ServicesAffected":[
+                  
+               ],
+               "PrivilegeEscalation":[
+                  
+               ],
+               "ResourceExposure":[
+                  
+               ],
+               "DataExfiltration":[
+                  
+               ],
+               "CredentialsExposure":[
+                  
+               ],
+               "InfrastructureModification":[
+                  
+               ]
+            }
+         }
+      ]
+    }
+}
+```

--- a/content/actions/what-perms-are-granted-to-role/dassana-action.yaml
+++ b/content/actions/what-perms-are-granted-to-role/dassana-action.yaml
@@ -1,0 +1,19 @@
+schema: 1.0
+id: WhatPermsAreGrantedToRole
+name: Get permissions and cloudsplaining findings for an IAM role
+
+cloud-type: aws
+service: iam
+resource-type: role
+
+runs-on: aws-lambda
+
+license:
+  url: https://www.apache.org/licenses/LICENSE-2.0
+  id: Apache
+author:
+  name: Kaushik Devireddy
+  email: kdev@ucla.edu
+compatible-type: policy-context
+labels:
+  - policy-context

--- a/content/actions/what-perms-are-granted-to-role/input.json
+++ b/content/actions/what-perms-are-granted-to-role/input.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "WhatPermsAreGrantedToRole",
+  "type": "object",
+  "properties": {
+    "roleName": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "roleName"
+  ]
+}

--- a/content/actions/what-perms-are-granted-to-role/requirements.txt
+++ b/content/actions/what-perms-are-granted-to-role/requirements.txt
@@ -1,0 +1,1 @@
+cloudsplaining==0.4.5

--- a/content/actions/what-perms-are-granted-to-role/src/handler.py
+++ b/content/actions/what-perms-are-granted-to-role/src/handler.py
@@ -1,0 +1,83 @@
+from json import load, loads, dumps
+from typing import Dict, Any
+
+from aws_lambda_powertools.utilities.typing import LambdaContext
+from aws_lambda_powertools.utilities.validation import validator
+from dassana.common.aws_client import DassanaAwsObject, parse_arn
+
+from cloudsplaining.scan.policy_document import PolicyDocument
+from cloudsplaining.shared.exclusions import Exclusions
+from cloudsplaining.output.policy_finding import PolicyFinding
+
+with open('input.json', 'r') as schema:
+    schema = load(schema)
+    dassana_aws = DassanaAwsObject()
+
+
+@validator(inbound_schema=schema)
+def handle(event: Dict[str, Any], context: LambdaContext):
+    role_name = event.get('roleName')
+    
+    attached_policies = []
+    inline_policies = []
+    
+    exclusions_config = {} # How can this be configured?
+    
+    client = dassana_aws.create_aws_client(context, 'iam', event.get('region'))
+    
+    response = client.list_attached_role_policies(
+        RoleName=role_name,
+        PathPrefix='/',
+        MaxItems=100
+    )
+    
+    for policy in response['AttachedPolicies']:
+        attached_policies.append({
+            'PolicyArn':policy['PolicyArn'], 
+            'PolicyName':policy['PolicyName']
+        })
+    
+    response = client.list_role_policies(
+        RoleName=role_name,
+        MaxItems=100
+    )
+    
+    for policy_name in response['PolicyNames']:
+        inline.policies({'PolicyName':policy_name})
+    
+    for policy in attached_policies:
+        policy_basic = client.get_policy(
+            PolicyArn=policy['PolicyArn']
+        )
+        
+        policy_detailed = client.get_policy_version(
+            PolicyArn=policy['PolicyArn'],
+            VersionId=policy_basic['Policy']['DefaultVersionId']
+        )
+        
+        policy['PolicyDocument'] = policy_detailed['PolicyVersion']['Document']
+        
+        policy_document = PolicyDocument(policy_detailed['PolicyVersion']['Document'])
+        exclusions = Exclusions(exclusions_config)
+        policy_finding = PolicyFinding(policy_document, exclusions)
+        
+        policy['PolicyFindings'] = policy_finding.results
+    
+    for policy in inline_policies:
+        policy_detailed = client.get_role_policy(
+            RoleName=role_name,
+            PolicyName=policy['PolicyName']
+        )
+        
+        policy['PolicyDocument'] = policy_detailed['Document']
+        
+        policy_document = PolicyDocument(policy_detailed['Document'])
+        exclusions = Exclusions(exclusions_config)
+        policy_finding = PolicyFinding(policy_document, exclusions)
+        
+        policy['PolicyFindings'] = policy_finding.results
+    
+    
+    response = dumps(attached_policies, default=str)
+    return {"result": loads(response)}
+

--- a/content/pkg/template.yaml
+++ b/content/pkg/template.yaml
@@ -574,6 +574,18 @@ Resources:
         Fn::GetAtt: [DassanaActionsRole, Arn]
       Timeout: 60
 
+  WhatPermsAreGrantedToRole:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handler.handle
+      Runtime: python3.7
+      CodeUri: ../actions/what-perms-are-granted-to-role
+      Layers:
+        - !Ref DassanaActionsPythonLayer
+      Role:
+        Fn::GetAtt: [DassanaActionsRole, Arn]
+      Timeout: 60
+
   PrismaCloudExtractor:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
Exploring #70. Separate from analyzing the entire account and all policies (cloudsplaining's main use-case), this action grabs the policies associated with a role and uses cloudsplaining to analyze only those specific policies. My test invocations with 2 or 3 AWS-managed policies per-role execute within 2 seconds, but caching the permission set (as mentioned in #70) may be required for roles with a larger number of attached policies. This action still needs pagination and error handling, better action naming, etc. but I wanted to get some initial feedback on the inputs and outputs. For example, should the full policy documents be returned with cloudsplaining documents (currently they are)? And should the number of cloudsplaining violations for each category be returned, in addition to the violations themselves (this could make it easier on the workflow side of things). 